### PR TITLE
Extension to associations for Pacecar

### DIFF
--- a/lib/pacecar/associations.rb
+++ b/lib/pacecar/associations.rb
@@ -28,12 +28,39 @@ module Pacecar
         end
       end
 
+      def has_updated_records(*names)
+        names.each do |name|
+          scope "updated_#{name}_since".to_sym, lambda { |since|
+            {
+              :conditions => [updated_conditions_for_name(name), { :since_time => since }]
+            }
+          }
+        end
+        unless names.first == names.last
+          scope "updated_#{names.join('_or_')}_since".to_sym, lambda { |since|
+            {
+              :conditions => [names.collect { |name| updated_conditions_for_name(name) }.join(' or '), { :since_time => since }]
+            }
+          }
+          scope "updated_#{names.join('_and_')}_since".to_sym, lambda { |since|
+            {
+              :conditions => [names.collect { |name| updated_conditions_for_name(name) }.join(' and '), { :since_time => since }]
+            }
+          }
+        end
+      end
+
+      
       protected
 
       def conditions_for_name(name)
         "((select count(*) from #{connection.quote_table_name(name)} where #{connection.quote_table_name(name)}.#{connection.quote_column_name reflections[name].primary_key_name} = #{quoted_table_name}.#{connection.quote_column_name primary_key} and #{connection.quote_table_name(name)}.#{connection.quote_column_name("created_at")} > :since_time) > 0)"
       end
 
+      def updated_conditions_for_name(name)
+        "((select count(*) from #{connection.quote_table_name(name)} where #{connection.quote_table_name(name)}.#{connection.quote_column_name reflections[name].primary_key_name} = #{quoted_table_name}.#{connection.quote_column_name primary_key} and #{connection.quote_table_name(name)}.#{connection.quote_column_name("updated_at")} > :since_time) > 0)"
+      end
+      
     end
   end
 end


### PR DESCRIPTION
Greetings --

I made an addition to the association code for Pacecar which adds the ability to find updated records in the same fashion as recent records.

In the model you would use:

has_updated_records :associated_table

Then in your code:

Table.updated_associated_table_since(1.week.ago) to find records updated in the last week.

It could stand to be refactored to handle both recent and updated -- there is some code duplication.  However, I wanted to make sure it worked (and impact the existing code as little as possible).

Thank you for Pacecar -- I like it a lot.

Matt
